### PR TITLE
Implemented issue #2, Naming: assert name should start with a_

### DIFF
--- a/bin/svalint.py
+++ b/bin/svalint.py
@@ -23,6 +23,7 @@ from rules.af_perf_no_ub_range_ant import NoUBRangeInAntAsrt
 from rules.af_func_missing_fablk import FuncMissingFABLK
 from rules.af_missing_elbl_prop import MissingEndLblProp
 from rules.af_missing_elbl_seq import MissingEndLblSEQ
+from rules.af_assert_prefix_a import AssertPrefixCheck
 
 class SVALinter(AsFigoLinter):
     """Linter that applies multiple rules on SVA code"""

--- a/src/rules/af_assert_prefix_a.py
+++ b/src/rules/af_assert_prefix_a.py
@@ -1,0 +1,37 @@
+# ----------------------------------------------------
+# SPDX-FileCopyrightText: AsFigo Technologies, UK
+# SPDX-FileCopyrightText: VerifWorks, India
+# SPDX-License-Identifier: MIT
+# Author: Himank Gangwal, June 07, 2025
+# ----------------------------------------------------
+
+from af_lint_rule import AsFigoLintRule
+import logging
+import anytree
+
+class AssertPrefixCheck(AsFigoLintRule):
+    """Checks if assert doesn't start with "a_" """
+
+    def __init__(self, linter):
+        self.linter = linter
+        self.ruleID = "ASSERT_START_WITH_A"
+
+    def apply(self, filePath: str, data: AsFigoLintRule.VeribleSyntax.SyntaxData):
+        for curNode in data.tree.iter_find_all({"tag": "kAssertionItem"}):
+            lvSvaCode = self.getHeaderName(curNode)
+            if (lvSvaCode[0:2] != "a_"):
+                message = (
+                    f"Debug: Found assert name without a_ prefix. Use a_ as assert prefix\n"
+                    f"Severly impacts verification completeness as errors may go undetected\n"
+                    f"{lvSvaCode}\n"
+                )
+
+                self.linter.logViolation(self.ruleID, message)
+        
+        
+                
+    def getHeaderName(self, header):
+        """Extracts the class name from a class declaration."""
+        for identifier in header.iter_find_all({"tag": "SymbolIdentifier"}):
+            return identifier.text
+        return "Unknown"

--- a/sva_tests/test_2/test_2_tb_f.sv
+++ b/sva_tests/test_2/test_2_tb_f.sv
@@ -1,0 +1,44 @@
+module counter_tb;
+   
+    logic clk;             
+    logic reset_n;          
+    logic enable;           
+    logic [7:0] counter;     
+    always #5 clk = ~clk;  
+
+    
+    counter_module uut (
+        .clk(clk),
+        .reset_n(reset_n),
+        .enable(enable),
+        .counter(counter)
+    );
+
+ 
+    property p_counter_within_limit;
+        @(posedge clk) disable iff (!reset_n) (counter <= 100);
+    endproperty
+
+    // Assertion using the property with a_ prefix for the name
+    counter_limit_check: assert property (p_counter_within_limit)
+        else $error("Assertion Failed: Counter exceeds the maximum allowed value!");
+
+    
+    initial begin
+        
+        clk = 0;
+        reset_n = 0;
+        enable = 0;        
+        #10 reset_n = 1;   
+        #10 enable = 1; 
+       
+        #100;              
+
+        // Force counter value to exceed the limit for testing
+        #10 enable = 0;    // Disable counter
+        uut.counter = 8'd120;  // Force counter to exceed the limit for testing
+        
+        #10 enable = 1;    
+        #20 $finish;      
+    end
+endmodule

--- a/sva_tests/test_2/test_2_tb_p.sv
+++ b/sva_tests/test_2/test_2_tb_p.sv
@@ -1,0 +1,44 @@
+module counter_tb;
+   
+    logic clk;             
+    logic reset_n;          
+    logic enable;           
+    logic [7:0] counter;     
+    always #5 clk = ~clk;  
+
+    
+    counter_module uut (
+        .clk(clk),
+        .reset_n(reset_n),
+        .enable(enable),
+        .counter(counter)
+    );
+
+ 
+    property p_counter_within_limit;
+        @(posedge clk) disable iff (!reset_n) (counter <= 100);
+    endproperty
+
+    // Assertion using the property with a_ prefix for the name
+    a_counter_limit_check: assert property (p_counter_within_limit)
+        else $error("Assertion Failed: Counter exceeds the maximum allowed value!");
+
+    
+    initial begin
+        
+        clk = 0;
+        reset_n = 0;
+        enable = 0;        
+        #10 reset_n = 1;   
+        #10 enable = 1; 
+       
+        #100;              
+
+        // Force counter value to exceed the limit for testing
+        #10 enable = 0;    // Disable counter
+        uut.counter = 8'd120;  // Force counter to exceed the limit for testing
+        
+        #10 enable = 1;    
+        #20 $finish;      
+    end
+endmodule


### PR DESCRIPTION
Implemented issue #2, Naming: assert name should start with a_
Also added pass and fail tests.